### PR TITLE
Split up controllers per Tab

### DIFF
--- a/coinTrack/FXMLDocument.fxml
+++ b/coinTrack/FXMLDocument.fxml
@@ -11,13 +11,13 @@
 <AnchorPane id="AnchorPane" prefHeight="647.0" prefWidth="787.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="coinTrack.FXMLDocumentController">
     <children>
         <Label fx:id="label" layoutX="126" layoutY="120" minHeight="16" minWidth="69" />
-      <TabPane prefHeight="647.0" prefWidth="787.0" tabClosingPolicy="UNAVAILABLE">
+      <TabPane fx:id="mainTabPane" prefHeight="647.0" prefWidth="787.0" tabClosingPolicy="UNAVAILABLE">
         <tabs>
           <Tab text="Tab1">
             <content>
               <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
                      <children>
-                        <fx:include source="../tabFXML/Tab1.fxml" />
+                        <fx:include source="../tabControllers/Tab1.fxml" />
                      </children></AnchorPane>
             </content>
           </Tab>
@@ -25,7 +25,7 @@
               <content>
                 <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
                      <children>
-                        <fx:include source="../tabFXML/Tab2.fxml" />
+                        <fx:include source="../tabControllers/Tab2.fxml" />
                      </children>
                   </AnchorPane>
               </content>

--- a/coinTrack/FXMLDocumentController.java
+++ b/coinTrack/FXMLDocumentController.java
@@ -42,7 +42,11 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.ProgressBar;
 import javafx.scene.control.SelectionMode;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.control.SplitMenuButton;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
@@ -81,6 +85,11 @@ public class FXMLDocumentController implements Initializable {
     @FXML protected TextField usernamePhone;
     @FXML protected PasswordField txtPassword;
     @FXML protected Label lblStatus;
+    @FXML private TabPane mainTabPane;
+    @FXML private TabPane graphTabPane;
+    @FXML private Tab barChartTab;
+    @FXML private Tab pieChartTab;
+    @FXML private Tab bubbleChartTab;
     
     // Bottom portion (button bar)
     @FXML private Button scanBtnT1;
@@ -109,6 +118,7 @@ public class FXMLDocumentController implements Initializable {
     @FXML private MenuItem numCoins10;
     @FXML private MenuItem numCoins25;
     @FXML private MenuItem numCoinsAll;
+    @FXML private Spinner<Integer> spinnerT2;
     
     // Bar Chart
     @FXML private BarChart barChart;
@@ -125,6 +135,13 @@ public class FXMLDocumentController implements Initializable {
     
     //========== Action Handlers ==========
     
+    /**
+     * Login button action handler.
+     * If the username and password are correct
+     * the button redirects users to the main 
+     * FXMLDocument.fxml page.
+     * @param event 
+     */
     @FXML public void login (ActionEvent event) {
         
         // If statement for testing purposes
@@ -149,351 +166,14 @@ public class FXMLDocumentController implements Initializable {
     }
     
     
-    // Testing this function
-    @FXML public void handleSearch(ActionEvent event) {
-        txtAreaT1.setText("Searching...");
-        if (coinHistory != null) {
-            if (searchSymbolT1.isSelected()) {
-                System.out.println("search by symbol");
-
-            } else {
-                System.out.println("search by name");
-                
-            }
-        } else {
-            coinHistory = new CoinHistory();
-
-            if (searchSymbolT1.isSelected()) {
-                System.out.println("search by symbol");
-
-            } else {
-                System.out.println("search by name");
-            }
-        }
-
-//        displayCoinText();
-    }
-    
-    @FXML
-    private void handleScan(ActionEvent event) {
-        System.out.println("Scanning");
-        tableViewT1.getItems().clear();
-//        displayCoinText();
-        if (searchGlobalStats.isArmed()){
-            displayGlobalStats();
-        } else {
-            displayCoinText();
-        }
-        
-    }
-    
-    @FXML
-    private void handleClear(ActionEvent event) {
-        System.out.println("hello");
-    }
-    
-    @FXML
-    private void handleSymbolSearch(ActionEvent event) {
-        searchNameT1.setSelected(false);
-        searchSymbolT1.setSelected(true);
-    }
-    
-    @FXML
-    private void handleNameSearch(ActionEvent event) {
-        searchNameT1.setSelected(true);
-        searchSymbolT1.setSelected(false);
-    }
-    
-    @FXML
-    private void handleSplitMenu(ActionEvent event) {
-        System.out.println("split menu clicked");
-    }
-    
-    @FXML
-    private void handleSearchCoins(ActionEvent event) {
-        splitMenuBtn.setText("Search Coins");
-        searchGlobalStats.setSelected(false);
-        searchCoins.setSelected(true);
-    }
-    
-    @FXML
-    private void handleGlobalStats(ActionEvent event) {
-        splitMenuBtn.setText("Search Globals");
-        searchGlobalStats.setSelected(true);
-        searchCoins.setSelected(false);
-    }
-    
-    @FXML
-    private void handleClearT1(ActionEvent event) {
-        tableViewT1.getItems().clear();
-        txtAreaT1.setText("");
-    }
-    
-    @FXML
-    private void handleTest(ActionEvent event) {
-        System.out.println("testing");
-    }
-    
-    
-    // ========== Tab 2 ==========
-    
-    
-    /**
-     * TODO Fix Graphing, not displaying correct
-     * number of coins. 
-     *  
-     */
-    
-    @FXML
-    private void handleScanT2(ActionEvent event) {
-        barChart.getData().clear();
-        barChart.layout();
-        coinHistory = new CoinHistory();
-        if (isSingleCoinScan) {
-            System.out.println("Sorry, havn't added this yet");
-            
-        } else {
-            displayMultiCoinGraph();
-        }
-    }
-    
-    @FXML
-    private void handleSearchT2(ActionEvent event) {
-        barChart.getData().clear();
-        barChart.layout();
-        if (coinHistory == null) {
-            displaySingleCoinGraph();
-        }
-    }
-    
-    @FXML
-    private void handle5Coins(ActionEvent event) {
-        coinsToGraph = 5;
-        numCoins.setText("5");
-    }
-    
-    @FXML
-    private void handle10Coins(ActionEvent event) {
-        coinsToGraph = 10;
-        numCoins.setText("10");
-    }
-    
-    @FXML
-    private void handle25Coins(ActionEvent event) {
-        coinsToGraph = 25;
-        numCoins.setText("25");
-    }
-    
-    @FXML
-    private void handleTotalCoins(ActionEvent event) {
-        coinsToGraph = 30;
-        numCoins.setText("All");
-    }
-    
-    @FXML
-    private void handleAllCoins(ActionEvent event) {
-        isSingleCoinScan = false;
-        splitMenuT2.setText("All Coins");
-    }
-    
-    @FXML
-    private void handleSingleCoin(ActionEvent event) {
-        isSingleCoinScan = true;
-        splitMenuT2.setText("Single Coin");
-    }
-    
-    @FXML
-    private void handleClearT2(ActionEvent event) {
-        barChart.getData().clear();
-        barChart.layout();
-        searchFieldT2.setText("");
-    }
     
     
     
-    // ========== HELPER METHODS ==========
-    
-    /**
-     * Display the api data to the screen. 
-     * 
-     * Currently this just posts it into the
-     * TextArea at the bottom of the page.
-     */
-    private void displayCoinText() {
-        cri = new CoinRankApi();
-        
-        cri.join();
-        count = 50;
-        System.out.println(cri.getLimit());
-        
-        // TODO: fix progress bar...
-        
-//        progBarT1.setProgress(0.0);
-//        progBarT1.progressProperty().unbind();
-//        progBarT1.progressProperty().bind(copyWorker.progressProperty());
-//        new Thread(copyWorker).start();
-        coinNamePrice = cri.getNamePrice();
-        coinList = cri.getCoinList();
-        displayMultiCoinView();
-        
-    }
-    
-    private void displayGlobalStats() {
-        globalStats = new GlobalCoinStats();
-        String text = "";
-        text += "Total Coins: " + globalStats.getTotalCoins() + "\n";
-        text += "Total Markets: " + globalStats.getTotalMarkets() + "\n";
-        text += "Total Exchanges: " + globalStats.getTotalExchanges() + "\n";
-        text += "Market Cap: " + globalStats.getTotalMarketCap() + "\n";
-        text += "Total 24h Volume: " + globalStats.getTotal24hVolume() + "\n";
-        
-        txtAreaT1.setText(text);
-    }
-    
-    
-    /**
-     * Display coin data to the table
-     */
-    private void displayMultiCoinView() {
-        
-        // READ THIS ************
-        /**
-         * Need to implement functionality that determines
-         * what tab the user is currently viewing.
-         */
-        TableColumn col1 = new TableColumn("Symbol");
-        TableColumn col2 = new TableColumn("Name");
-        TableColumn col3 = new TableColumn("Price");
-        TableColumn col4 = new TableColumn("Rank");
-        TableColumn col5 = new TableColumn("Change");
-        TableColumn col6 = new TableColumn("Volume");
-        
-        col1.setCellValueFactory(new PropertyValueFactory<>("symbol"));
-        col2.setCellValueFactory(new PropertyValueFactory<>("name"));
-        col3.setCellValueFactory(new PropertyValueFactory<>("price"));
-        col4.setCellValueFactory(new PropertyValueFactory<>("rank"));
-        col5.setCellValueFactory(new PropertyValueFactory<>("change"));
-        col6.setCellValueFactory(new PropertyValueFactory<>("volume"));
-        
-        tableViewT1.getColumns().addAll(col1,col2,col3,col4,col5,col6);
-        ObservableList<SingleCoin> obvList = FXCollections.observableArrayList(coinList);
-        tableViewT1.setItems(obvList);
-        tableViewT1.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
-        // Allows user to double click a table row and display info in textArea
-        tableViewT1.setRowFactory(tv -> {
-            TableRow<SingleCoin> row = new TableRow<>();
-            row.setOnMouseClicked(new EventHandler<MouseEvent>() {
-                @Override
-                public void handle(MouseEvent event) {
-                    if (event.getClickCount() == 2 && (!row.isEmpty())) {
-                        SingleCoin rowData = row.getItem();
-                        System.out.println(rowData);
-//                        txtAreaT1.setText(rowData.getIconUrl());
-                        String imgPath = rowData.getIconUrl();
-
-                        // Attempting to resize the coin logo image.
-                        webViewT1.setPrefHeight(56);
-                        webViewT1.setPrefWidth(56);
-                        webViewT1.getEngine().load(imgPath);
-                    }
-                }
-            });
-            return row;
-        });
-    }
-    
-
-    /**
-     * Display historical data for a single coin
-     */
-    public void displaySingleCoinGraph() {
-        System.out.println("displaying graph");
-        // Get the string/int from the text field.
-        if (searchFieldT2.getText().isEmpty()){
-            searchFieldT2.setText("Coin name or id");
-        } else if (Character.isDigit(searchFieldT2.getText().charAt(0))) {
-            // Create a CoinHistory object and pass it the id.
-            CoinHistory coinHist = new CoinHistory(Integer.parseInt(
-                    searchFieldT2.getText()));
-            // Save the data to a HashMap variable
-            singleHistoryMap = coinHist.getSingleHistory();
-        } else {
-            // TODO:
-            // Here we should add the ability to check for a name entry
-            searchFieldT2.setText("no string compatability yet");
-        }
-        // Add entries from singleHistoryMap into series1
-        for (Map.Entry<Double, String> entry : singleHistoryMap.entrySet()) {
-            series4.getData().add(new XYChart.Data(
-                    entry.getValue(), entry.getKey()));
-        }
-        // Add series1 to the barChartData, then add that to the barChart
-        barChartData2.add(series4);
-        barChart.setData(barChartData2);
-        
-        /**
-         * THIS IS FOR TESTING.
-         * THIS IS NOT MY CODE.
-         * 
-         * Implements scrolling using the mouse wheel on the graph.
-         */
-        final double SCALE_DELTA = 1.1;
-        barChart.setOnScroll(new EventHandler<ScrollEvent>() {
-            public void handle(ScrollEvent event) {
-                event.consume();
-
-                if (event.getDeltaY() == 0) {
-                    return;
-                }
-
-                double scaleFactor = (event.getDeltaY() > 0) ? SCALE_DELTA : 1 / SCALE_DELTA;
-
-                barChart.setScaleX(barChart.getScaleX() * scaleFactor);
-                barChart.setScaleY(barChart.getScaleY() * scaleFactor);
-            }
-        });
-
-        barChart.setOnMousePressed(new EventHandler<MouseEvent>() {
-            public void handle(MouseEvent event) {
-                if (event.getClickCount() == 2) {
-                    barChart.setScaleX(1.0);
-                    barChart.setScaleY(1.0);
-                }
-            }
-        });
-        
-    }
-    
-    /**
-     * Display / Rank all coin prices
-     */
-    public void displayMultiCoinGraph() {
-        System.out.println("displaying graph");
-//        coinHistory.join();
-        historyMap = coinHistory.getPriceDate();
-        int count = 0;
-        for (Map.Entry<String, Integer> entry : historyMap.entrySet()) {
-//            count++;
-//            if (coinsToGraph < 25 && count < coinsToGraph) {
-//                break;
-//            }
-            series1.getData().add(new XYChart.Data(
-                    entry.getKey(), entry.getValue()));
-        }
-        barChartData.add(series1);
-        barChart.setData(barChartData);
-    }
     
     @Override
     public void initialize (URL url, ResourceBundle rb) {
      
-        barChartData = FXCollections.observableArrayList();
-        barChartData2 = FXCollections.observableArrayList();
-        series1 = new BarChart.Series<>();
-        series4 = new BarChart.Series<>();
-        series1.setName("Data");
-        series4.setName("Prices");
-
+        
     }
 
 }

--- a/tabControllers/Tab1.fxml
+++ b/tabControllers/Tab1.fxml
@@ -16,7 +16,7 @@
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.web.WebView?>
 
-<AnchorPane id="AnchorPane" prefHeight="647.0" prefWidth="787.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="coinTrack.FXMLDocumentController">
+<AnchorPane id="AnchorPane" prefHeight="647.0" prefWidth="787.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="tabControllers.Tab1Controller">
     <children>
       <MenuBar prefHeight="28.0" prefWidth="787.0">
         <menus>
@@ -39,14 +39,12 @@
       </MenuBar>
       <ToolBar layoutX="14.0" layoutY="528.0" prefHeight="34.0" prefWidth="759.0">
         <items>
-            <CheckBox fx:id="searchGlobalStats" onAction="#handleSearchCoins" mnemonicParsing="false" text="Global Stats" />
-            <CheckBox fx:id="searchCoins" onAction="#handleGlobalStats" mnemonicParsing="false" text="All Coins" />
+            <CheckBox fx:id="searchGlobalStats" mnemonicParsing="false" text="Global Stats" />
+            <CheckBox fx:id="searchCoins" mnemonicParsing="false" text="All Coins" />
             <Button fx:id="scanBtnT1" accessibleHelp="Scan for updates on coin prices" defaultButton="true" mnemonicParsing="false" onAction="#handleScan" text="Scan" underline="true" />
             <Button fx:id="clearBtnT1" accessibleHelp="Clear table" mnemonicParsing="false" onAction="#handleClearT1" text="Clear" />
             <TextField fx:id="searchFieldT1" />
           <Button fx:id="searchBtnT1" accessibleHelp="Search for a specific cryptocurrency" mnemonicParsing="false" onAction="#handleSearch" text="Search" />
-            <CheckBox fx:id="searchSymbolT1" mnemonicParsing="false" onAction="#handleSymbolSearch" text="Symbol" />
-            <CheckBox fx:id="searchNameT1" mnemonicParsing="false" onAction="#handleNameSearch" selected="true" text="Name" />
             <ProgressIndicator fx:id="progIndT1" accessibleHelp="Loading Results" progress="0.0" />
         </items>
       </ToolBar>

--- a/tabControllers/Tab1Controller.java
+++ b/tabControllers/Tab1Controller.java
@@ -1,0 +1,238 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package tabControllers;
+
+import coinClasses.CoinHistory;
+import coinClasses.CoinRankApi;
+import coinClasses.GlobalCoinStats;
+import coinClasses.SingleCoin;
+import coinClasses.SingleCoinHistory;
+import java.net.URL;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.ResourceBundle;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.concurrent.Task;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.fxml.FXML;
+import javafx.fxml.Initializable;
+import javafx.scene.Scene;
+import javafx.scene.chart.BarChart;
+import javafx.scene.chart.CategoryAxis;
+import javafx.scene.chart.NumberAxis;
+import javafx.scene.chart.XYChart;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.PasswordField;
+import javafx.scene.control.ProgressBar;
+import javafx.scene.control.SelectionMode;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.SplitMenuButton;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableRow;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
+import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.scene.image.Image;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+
+
+
+/**
+ *
+ * @author Kyle
+ */
+public class Tab1Controller implements Initializable{
+    
+    private LinkedHashMap<String, String> coinNamePrice;
+    private LinkedList<SingleCoin> coinList;
+    private int count;
+    private Task copyWorker;
+    private Image icon;
+    private WebEngine webEngine;
+    private CoinHistory coinHistory;
+    private LinkedList<SingleCoinHistory> history;
+    private LinkedHashMap<String, Integer> historyMap;
+    private LinkedHashMap<Double, String> singleHistoryMap;
+    private int coinsToGraph = 25;
+    private boolean isSingleCoinScan;
+    private GlobalCoinStats globalStats;
+    private CoinRankApi cri;
+    
+    protected Scene scene;
+    @FXML protected TextField usernamePhone;
+    @FXML protected PasswordField txtPassword;
+    @FXML protected Label lblStatus;
+    
+    // Bottom portion (button bar)
+    @FXML private TextArea txtAreaT1;
+    @FXML private WebView webViewT1;
+    @FXML private CheckBox searchCoins;
+    @FXML private CheckBox searchGlobalStats;
+    
+    // Table View
+    @FXML private TableView<SingleCoin> tableViewT1;
+    
+    
+    /**
+     * Search for a specific coin. 
+     * 
+     * This needs work.
+     * 
+     * Determine if the entered text is a string
+     * or an integer. Then call the coin api, and
+     * display the information for that coin.
+     * @param event 
+     */
+    @FXML 
+    public void handleSearch(ActionEvent event) {
+        txtAreaT1.setText("Searching...");
+        coinHistory = new CoinHistory();
+    }
+    
+    /**
+     * This method handles both scanning for all coins
+     * and all markets / exchanges. 
+     * Simple logic determines the selected checkBoxes, then
+     * calls the appropriate classes and displays data. 
+     * @param event 
+     */
+    @FXML
+    private void handleScan(ActionEvent event) {
+        System.out.println("Scanning");
+        tableViewT1.getItems().clear();
+        txtAreaT1.setText("");
+        if (searchGlobalStats.isSelected() && searchCoins.isSelected()){
+            displayGlobalStats();
+            displayCoinText();
+        } else if (searchGlobalStats.isSelected()){
+            displayGlobalStats();
+        } else if (searchCoins.isSelected()) {
+            displayCoinText();
+        }
+    }
+    
+    // ========== HELPER METHODS ==========
+    
+    /**
+     * Display the api data to the screen. 
+     * 
+     * Currently this just posts it into the
+     * TextArea at the bottom of the page.
+     */
+    private void displayCoinText() {
+        cri = new CoinRankApi();
+        
+        cri.join();
+        count = 50;
+        System.out.println(cri.getLimit());
+        
+        // TODO: fix progress bar...
+        
+//        progBarT1.setProgress(0.0);
+//        progBarT1.progressProperty().unbind();
+//        progBarT1.progressProperty().bind(copyWorker.progressProperty());
+//        new Thread(copyWorker).start();
+        coinNamePrice = cri.getNamePrice();
+        coinList = cri.getCoinList();
+        displayMultiCoinView();
+        
+    }
+    
+    private void displayGlobalStats() {
+        globalStats = new GlobalCoinStats();
+        String text = "";
+        text += "Total Coins: " + globalStats.getTotalCoins() + "\n";
+        text += "Total Markets: " + globalStats.getTotalMarkets() + "\n";
+        text += "Total Exchanges: " + globalStats.getTotalExchanges() + "\n";
+        text += "Market Cap: " + globalStats.getTotalMarketCap() + "\n";
+        text += "Total 24h Volume: " + globalStats.getTotal24hVolume() + "\n";
+        
+        txtAreaT1.setText(text);
+    }
+    
+    
+    /**
+     * Display coin data to the table
+     */
+    private void displayMultiCoinView() {
+        
+        // READ THIS ************
+        /**
+         * Need to implement functionality that determines
+         * what tab the user is currently viewing.
+         */
+        TableColumn col1 = new TableColumn("Symbol");
+        TableColumn col2 = new TableColumn("Name");
+        TableColumn col3 = new TableColumn("Price (USD)");
+        TableColumn col4 = new TableColumn("Rank");
+        TableColumn col5 = new TableColumn("Change");
+        TableColumn col6 = new TableColumn("Volume");
+        
+        col1.setCellValueFactory(new PropertyValueFactory<>("symbol"));
+        col2.setCellValueFactory(new PropertyValueFactory<>("name"));
+        col3.setCellValueFactory(new PropertyValueFactory<>("price"));
+        col4.setCellValueFactory(new PropertyValueFactory<>("rank"));
+        col5.setCellValueFactory(new PropertyValueFactory<>("change"));
+        col6.setCellValueFactory(new PropertyValueFactory<>("volume"));
+        
+        tableViewT1.getColumns().addAll(col1,col2,col3,col4,col5,col6);
+        ObservableList<SingleCoin> obvList = FXCollections.observableArrayList(coinList);
+        tableViewT1.setItems(obvList);
+        tableViewT1.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+        // Allows user to double click a table row and display info in textArea
+        tableViewT1.setRowFactory(tv -> {
+            TableRow<SingleCoin> row = new TableRow<>();
+            row.setOnMouseClicked(new EventHandler<MouseEvent>() {
+                @Override
+                public void handle(MouseEvent event) {
+                    if (event.getClickCount() == 2 && (!row.isEmpty())) {
+                        SingleCoin rowData = row.getItem();
+                        System.out.println(rowData);
+//                        txtAreaT1.setText(rowData.getIconUrl());
+                        String imgPath = rowData.getIconUrl();
+
+                        // Attempting to resize the coin logo image.
+                        webViewT1.setPrefHeight(56);
+                        webViewT1.setPrefWidth(56);
+                        webViewT1.getEngine().load(imgPath);
+                    }
+                }
+            });
+            return row;
+        });
+    }
+    
+    
+    /**
+     * Clears the tableView and textArea.
+     * @param event 
+     */
+    @FXML
+    private void handleClearT1(ActionEvent event) {
+        System.out.println("clearing data");
+        tableViewT1.getItems().clear();
+        txtAreaT1.setText("");
+    }
+    
+    
+    
+
+    @Override
+    public void initialize(URL location, ResourceBundle resources) {
+        
+    }
+    
+}

--- a/tabControllers/Tab2.fxml
+++ b/tabControllers/Tab2.fxml
@@ -7,10 +7,11 @@
 <?import javafx.scene.chart.PieChart?>
 <?import javafx.scene.control.Accordion?>
 <?import javafx.scene.control.Button?>
-<?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
+<?import javafx.scene.control.ProgressIndicator?>
+<?import javafx.scene.control.Spinner?>
 <?import javafx.scene.control.SplitMenuButton?>
 <?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.control.Tab?>
@@ -21,8 +22,10 @@
 <?import javafx.scene.control.ToolBar?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.web.WebView?>
+<?import javafx.scene.control.SpinnerValueFactory.IntegerSpinnerValueFactory?>
+<?import javafx.scene.control.* ?>
 
-<AnchorPane id="AnchorPane" prefHeight="647.0" prefWidth="787.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="coinTrack.FXMLDocumentController">
+<AnchorPane id="AnchorPane" prefHeight="647.0" prefWidth="787.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="tabControllers.Tab2Controller">
     <children>
       <MenuBar prefHeight="28.0" prefWidth="787.0">
         <menus>
@@ -45,12 +48,6 @@
       </MenuBar>
       <ToolBar layoutX="14.0" layoutY="528.0" prefHeight="34.0" prefWidth="762.0">
         <items>
-            <SplitMenuButton fx:id="splitMenuT2" mnemonicParsing="false" text="Select">
-              <items>
-                <MenuItem fx:id="searchAllCoins" mnemonicParsing="false" onAction="#handleAllCoins" text="All Coins" />
-                <MenuItem fx:id="searchSingleCoins" mnemonicParsing="false" onAction="#handleSingleCoin" text="Single Coin" />
-              </items>
-            </SplitMenuButton>
             <SplitMenuButton fx:id="numCoins" mnemonicParsing="false" text="Amount">
               <items>
                 <MenuItem fx:id="numCoins5" mnemonicParsing="false" onAction="#handle5Coins" text="5" />
@@ -59,12 +56,12 @@
                   <MenuItem fx:id="numCoinsAll" mnemonicParsing="false" onAction="#handleTotalCoins" text="All" />
               </items>
             </SplitMenuButton>
+            <Spinner fx:id="spinnerT2" />
             <Button fx:id="scanBtnT2" accessibleHelp="Scan for updates on coin prices" defaultButton="true" mnemonicParsing="false" onAction="#handleScanT2" text="Scan" underline="true" />
-            <Button fx:id="clearBtnT2" onAction="#handleClearT2" mnemonicParsing="false" text="Clear" />
+            <Button fx:id="clearBtnT2" mnemonicParsing="false" onAction="#handleClearT2" text="Clear" />
             <TextField fx:id="searchFieldT2" />
           <Button fx:id="searchBtnT2" accessibleHelp="Search for a specific cryptocurrency" mnemonicParsing="false" onAction="#handleSearchT2" text="Search" />
-            <CheckBox fx:id="searchSymbolT2" mnemonicParsing="false" onAction="#handleSymbolSearch" text="Symbol" />
-            <CheckBox fx:id="searchNameT2" mnemonicParsing="false" onAction="#handleNameSearch" selected="true" text="Name" />
+            <ProgressIndicator fx:id="progIndT2" progress="0.0" />
         </items>
       </ToolBar>
       <SplitPane dividerPositions="0.8770161290322581" layoutY="28.0" orientation="VERTICAL" prefHeight="498.0" prefWidth="787.0">
@@ -98,9 +95,9 @@
                         </AnchorPane>
                       <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="160.0" prefWidth="100.0">
                            <children>
-                              <TabPane prefHeight="430.0" prefWidth="614.0" tabClosingPolicy="UNAVAILABLE">
+                              <TabPane fx:id="graphTabPane" prefHeight="430.0" prefWidth="614.0" tabClosingPolicy="UNAVAILABLE">
                                 <tabs>
-                                  <Tab text="Bar Chart">
+                                  <Tab fx:id="barChartTab" text="Bar Chart">
                                     <content>
                                       <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
                                              <children>
@@ -116,7 +113,7 @@
                                           </AnchorPane>
                                     </content>
                                   </Tab>
-                                  <Tab text="Pie Chart">
+                                  <Tab fx:id="pieChartTab" text="Pie Chart">
                                     <content>
                                       <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
                                              <children>
@@ -125,7 +122,7 @@
                                           </AnchorPane>
                                     </content>
                                   </Tab>
-                                    <Tab text="Bubble Chart">
+                                    <Tab fx:id="bubbleChartTab" text="Bubble Chart">
                                       <content>
                                         <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
                                              <children>

--- a/tabControllers/Tab2Controller.java
+++ b/tabControllers/Tab2Controller.java
@@ -1,0 +1,312 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package tabControllers;
+
+import coinClasses.CoinHistory;
+import coinClasses.CoinRankApi;
+import coinClasses.GlobalCoinStats;
+import coinClasses.SingleCoin;
+import coinClasses.SingleCoinHistory;
+import java.net.URL;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.ResourceBundle;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.concurrent.Task;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.fxml.FXML;
+import javafx.fxml.Initializable;
+import javafx.scene.Scene;
+import javafx.scene.chart.BarChart;
+import javafx.scene.chart.CategoryAxis;
+import javafx.scene.chart.NumberAxis;
+import javafx.scene.chart.XYChart;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.PasswordField;
+import javafx.scene.control.ProgressBar;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.SpinnerValueFactory;
+import javafx.scene.control.SplitMenuButton;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
+import javafx.scene.image.Image;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.input.ScrollEvent;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+
+/**
+ *
+ * @author Kyle
+ */
+public class Tab2Controller implements Initializable{
+    
+    private LinkedHashMap<String, String> coinNamePrice;
+    private LinkedList<SingleCoin> coinList;
+    private int count;
+    private Task copyWorker;
+    private Image icon;
+    private WebEngine webEngine;
+    private CoinHistory coinHistory;
+    private LinkedList<SingleCoinHistory> history;
+    private LinkedHashMap<String, Integer> historyMap;
+    private LinkedHashMap<Double, String> singleHistoryMap;
+    private int coinsToGraph = 25;
+    private boolean isSingleCoinScan;
+    private GlobalCoinStats globalStats;
+    private CoinRankApi cri;
+    
+    protected Scene scene;
+    @FXML protected TextField usernamePhone;
+    @FXML protected PasswordField txtPassword;
+    @FXML protected Label lblStatus;
+    @FXML private TabPane mainTabPane;
+    @FXML private TabPane graphTabPane;
+    @FXML private Tab barChartTab;
+    @FXML private Tab pieChartTab;
+    @FXML private Tab bubbleChartTab;
+    
+    // Bottom portion (button bar)
+    @FXML private Button scanBtnT1;
+    @FXML private Button searchBtnT1;
+    @FXML private TextArea txtAreaT1;
+    @FXML private WebView webViewT1;
+    @FXML private ProgressBar progBarT1;
+    @FXML private CheckBox searchSymbolT1;
+    @FXML private CheckBox searchNameT1;
+    @FXML private SplitMenuButton splitMenuBtn;
+    @FXML private CheckBox searchCoins;
+    @FXML private CheckBox searchGlobalStats;
+    
+    // Bottom portion Tab 2
+    @FXML private SplitMenuButton splitMenuT2;
+    @FXML private Button searchBtnT2;
+    @FXML private MenuItem searchAllCoins;
+    @FXML private MenuItem searchSingleCoin;
+    @FXML private WebView webViewT2;
+    @FXML private ProgressBar progBarT2;
+    @FXML private CheckBox searchSymbolT2;
+    @FXML private CheckBox searchNameT2;
+    @FXML private TextField searchFieldT2;
+    @FXML private SplitMenuButton numCoins;
+    @FXML private MenuItem numCoins5;
+    @FXML private MenuItem numCoins10;
+    @FXML private MenuItem numCoins25;
+    @FXML private MenuItem numCoinsAll;
+    @FXML private Spinner<Integer> spinnerT2;
+    
+    // Bar Chart
+    @FXML private BarChart barChart;
+    @FXML private CategoryAxis xAxis;
+    @FXML private NumberAxis yAxis;
+    private XYChart.Series series1;
+    private XYChart.Series series4;
+    private ObservableList<XYChart.Series<String, Number>> barChartData;
+    private ObservableList<XYChart.Series<String, Number>> barChartData2;
+    
+    // Table View
+    @FXML private TableView<SingleCoin> tableViewT1;
+    
+    
+    // ========== Tab 2 ==========
+    
+    
+    /**
+     * TODO Fix Graphing, not displaying correct
+     * number of coins. 
+     *  
+     */
+    
+    @FXML
+    private void handleScanT2(ActionEvent event) {
+        if (graphTabPane.getSelectionModel().getSelectedItem() == barChartTab) {
+            System.out.println("bar chart selected");
+            barChart.getData().clear();
+            barChart.layout();
+            coinHistory = new CoinHistory();
+            if (isSingleCoinScan) {
+                System.out.println("Sorry, havn't added this yet");
+
+            } else {
+                displayMultiCoinGraph();
+            }
+        } else if (graphTabPane.getSelectionModel().getSelectedItem() == pieChartTab) {
+            System.out.println("pie chart selected");
+        } else {
+            System.out.println("bubble chart selected");
+        }
+
+    }
+    
+    @FXML
+    private void handleSearchT2(ActionEvent event) {
+        if (graphTabPane.getSelectionModel().getSelectedItem() == barChartTab) {
+            System.out.println("bar chart selected");
+            barChart.getData().clear();
+            barChart.layout();
+            if (coinHistory == null) {
+                displaySingleCoinGraph();
+            }
+        } else if (graphTabPane.getSelectionModel().getSelectedItem() == pieChartTab) {
+            System.out.println("pie chart selected");
+        } else {
+            System.out.println("bubble chart selected");
+        }
+    }
+    
+    @FXML
+    private void handle5Coins(ActionEvent event) {
+        coinsToGraph = 5;
+        numCoins.setText("5");
+    }
+    
+    @FXML
+    private void handle10Coins(ActionEvent event) {
+        coinsToGraph = 10;
+        numCoins.setText("10");
+    }
+    
+    @FXML
+    private void handle25Coins(ActionEvent event) {
+        coinsToGraph = 25;
+        numCoins.setText("25");
+    }
+    
+    @FXML
+    private void handleTotalCoins(ActionEvent event) {
+        coinsToGraph = 30;
+        numCoins.setText("All");
+    }
+    
+    @FXML
+    private void handleAllCoins(ActionEvent event) {
+        isSingleCoinScan = false;
+        splitMenuT2.setText("All Coins");
+    }
+    
+    @FXML
+    private void handleSingleCoin(ActionEvent event) {
+        isSingleCoinScan = true;
+        splitMenuT2.setText("Single Coin");
+    }
+    
+    @FXML
+    private void handleClearT2(ActionEvent event) {
+        barChart.getData().clear();
+        barChart.layout();
+        searchFieldT2.setText("");
+    }
+    
+    
+    
+    
+
+    /**
+     * Display historical data for a single coin
+     */
+    public void displaySingleCoinGraph() {
+        System.out.println("displaying graph");
+        // Get the string/int from the text field.
+        if (searchFieldT2.getText().isEmpty()){
+            searchFieldT2.setText("Coin name or id");
+        } else if (Character.isDigit(searchFieldT2.getText().charAt(0))) {
+            // Create a CoinHistory object and pass it the id.
+            CoinHistory coinHist = new CoinHistory(Integer.parseInt(
+                    searchFieldT2.getText()));
+            // Save the data to a HashMap variable
+            singleHistoryMap = coinHist.getSingleHistory();
+        } else {
+            // TODO:
+            // Here we should add the ability to check for a name entry
+            searchFieldT2.setText("no string compatability yet");
+        }
+        // Add entries from singleHistoryMap into series1
+        for (Map.Entry<Double, String> entry : singleHistoryMap.entrySet()) {
+            series4.getData().add(new XYChart.Data(
+                    entry.getValue(), entry.getKey()));
+        }
+        // Add series1 to the barChartData, then add that to the barChart
+        barChartData2.add(series4);
+        barChart.setData(barChartData2);
+        
+        /**
+         * THIS IS FOR TESTING.
+         * THIS IS NOT MY CODE.
+         * 
+         * Implements scrolling using the mouse wheel on the graph.
+         */
+        final double SCALE_DELTA = 1.1;
+        barChart.setOnScroll(new EventHandler<ScrollEvent>() {
+            public void handle(ScrollEvent event) {
+                event.consume();
+
+                if (event.getDeltaY() == 0) {
+                    return;
+                }
+
+                double scaleFactor = (event.getDeltaY() > 0) ? SCALE_DELTA : 1 / SCALE_DELTA;
+
+                barChart.setScaleX(barChart.getScaleX() * scaleFactor);
+                barChart.setScaleY(barChart.getScaleY() * scaleFactor);
+            }
+        });
+
+        barChart.setOnMousePressed(new EventHandler<MouseEvent>() {
+            public void handle(MouseEvent event) {
+                if (event.getClickCount() == 2) {
+                    barChart.setScaleX(1.0);
+                    barChart.setScaleY(1.0);
+                }
+            }
+        });
+        
+    }
+    
+    /**
+     * Display / Rank all coin prices
+     */
+    public void displayMultiCoinGraph() {
+        System.out.println("displaying graph");
+//        coinHistory.join();
+        historyMap = coinHistory.getPriceDate();
+        int count = 0;
+        for (Map.Entry<String, Integer> entry : historyMap.entrySet()) {
+//            count++;
+//            if (coinsToGraph < 25 && count < coinsToGraph) {
+//                break;
+//            }
+            series1.getData().add(new XYChart.Data(
+                    entry.getKey(), entry.getValue()));
+        }
+        barChartData.add(series1);
+        barChart.setData(barChartData);
+    }
+    
+
+    @Override
+    public void initialize(URL location, ResourceBundle resources) {
+        barChartData = FXCollections.observableArrayList();
+        barChartData2 = FXCollections.observableArrayList();
+        series1 = new BarChart.Series<>();
+        series4 = new BarChart.Series<>();
+        series1.setName("Data");
+        series4.setName("Prices");
+        
+        final int initialVal = 25;
+        SpinnerValueFactory<Integer> valFact = new SpinnerValueFactory.IntegerSpinnerValueFactory(3, 100, initialVal);
+//        spinnerT2.setValueFactory(valFact);
+    }
+    
+}


### PR DESCRIPTION
I reversed the change of having a single document controller and re-created two different controllers, one for each tab. I think this makes more sense and prevents us from having to label FXML elements with T1 or T2 to distinguish which tab they belong to.